### PR TITLE
Update cli.py for < Python 3.10 compatibility

### DIFF
--- a/llm_toolbox/cli.py
+++ b/llm_toolbox/cli.py
@@ -590,11 +590,10 @@ def process_command(
     """
     Process a given command using a specific template and optional lines.
     """
-    match template:
-        case "summarize" | "commitgen":
-            prompt_input = "".join(prompt_input).strip()
-        case _:
-            prompt_input = " ".join(prompt_input).strip()
+    if template in ["summarize", "commitgen"]:
+        prompt_input = "".join(prompt_input).strip()
+    else:
+        prompt_input = " ".join(prompt_input).strip()
 
     if not prompt_input:
         if not sys.stdin.isatty():


### PR DESCRIPTION
I changed the use of match to if-else so it doesn't break on python older than 3.10