### PR TITLE
Add `release.yml` with `uv publish` trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ github.run_id }}
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    if: "!github.event.release.prerelease"
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ github.run_id }}
+          path: dist/
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Check release tag
+        id: stable_tag
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "publish=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::notice::Skipping publish for non-stable tag: $TAG"
+          echo "publish=false" >>"$GITHUB_OUTPUT"
+
+      - name: Publish to PyPI with uv
+        if: steps.stable_tag.outputs.publish == 'true'
+        run: uv publish --trusted-publishing always --check-url https://pypi.org/simple


### PR DESCRIPTION
## What changed

* Add `.github/workflows/release.yml`.
* Use `uv publish --trusted-publishing always` (OIDC, keyless).
* Build and publish split into two jobs.
* Publish only on stable semver tags (`vX.Y.Z` or `X.Y.Z`).

## Why

Keyless trusted publishing via OIDC is the recommended PyPI approach.
`uv publish` replaces `pypa/gh-action-pypi-publish`.

## How to test

* Create a pre-release on GitHub; the publish job should be skipped.
* Create a stable release (e.g., `v1.0.0`); the package should appear on PyPI.
* Verify the trusted publisher is configured on pypi.org for `sderev/lmtoolbox`.

## Risk

* Requires PyPI trusted publisher configured for this repo.
* No GitHub environment protection rules (environment block omitted).

## Changelog fragment

No (internal CI change, not user-facing).